### PR TITLE
Update README.md example code to fix TypeScript error

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ import SolanaWallets from 'solana-wallets-vue';
 // You can either import the default styles or create your own.
 import 'solana-wallets-vue/styles.css';
 
-import {WalletAdapterNetwork} from "@solana/wallet-adapter-base"
+import { WalletAdapterNetwork } from "@solana/wallet-adapter-base"
 
 import {
   PhantomWalletAdapter,

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ import SolanaWallets from 'solana-wallets-vue';
 // You can either import the default styles or create your own.
 import 'solana-wallets-vue/styles.css';
 
+import {WalletAdapterNetwork} from "@solana/wallet-adapter-base"
+
 import {
   PhantomWalletAdapter,
   SlopeWalletAdapter,
@@ -35,7 +37,7 @@ const walletOptions = {
   wallets: [
     new PhantomWalletAdapter(),
     new SlopeWalletAdapter(),
-    new SolflareWalletAdapter({ network: 'devnet' }),
+    new SolflareWalletAdapter({ network: WalletAdapterNetwork.Devnet }),
   ],
   autoConnect: true,
 }


### PR DESCRIPTION
When using this package in TypeScript project, example code will generate error about incompatible types:

<img width="920" alt="image" src="https://user-images.githubusercontent.com/26169825/153185250-82f90463-0195-4cb6-83c0-83bae4cc816f.png">
