### PR TITLE
Change `beforeunload` to `unload`

### DIFF
--- a/src/createWalletStore.ts
+++ b/src/createWalletStore.ts
@@ -149,7 +149,7 @@ export const createWalletStore = ({
   if (typeof window !== "undefined") {
     // Ensure the wallet listeners are invalidated before refreshing the page.
     // This is because Vue does not unmount components when the page is being refreshed.
-    window.addEventListener("beforeunload", invalidateListeners);
+    window.addEventListener("unload", invalidateListeners);
   }
 
   // Connect the wallet.


### PR DESCRIPTION
Invalidation of the wallet events should only be done when the page is truly terminated.
`unload` instead of `beforeunload` fixes this.
https://github.com/lorisleiva/solana-wallets-vue/issues/24#issuecomment-1183764520
![image](https://user-images.githubusercontent.com/2179775/178851305-dc245964-d05e-4b65-98f1-d81054c4d9c4.png)