### PR TITLE
fix: types are now exported correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "exports": {
     ".": {
       "import": "./dist/solana-wallets-vue.mjs",
-      "require": "./dist/solana-wallets-vue.umd.js"
+      "require": "./dist/solana-wallets-vue.umd.js",
+      "types": "./dist/index.d.ts"
     },
     "./styles.css": "./styles.css",
     "./postcss.config.js": "./postcss.config.js"


### PR DESCRIPTION
Before when trying to import the package you would get this error: `Could not find a declaration file for module 'solana-wallets-vue'`