### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solana-wallets-vue",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Solana wallet integration for Vue 3",
   "author": "Loris Leiva",
   "license": "MIT",


### PR DESCRIPTION
## 🔖 Bump Version to 0.7.0

### 📌 Summary
This PR bumps the version of `solana-wallets-vue` to **0.7.0** for minor release on npm.